### PR TITLE
Set template mode to CP only if a CP request

### DIFF
--- a/src/ContactFormExtensions.php
+++ b/src/ContactFormExtensions.php
@@ -146,7 +146,9 @@ class ContactFormExtensions extends Plugin
                 $e->message->setHtmlBody($html);
 
                 // Set the template mode back to Control Panel
-                Craft::$app->view->setTemplateMode(View::TEMPLATE_MODE_CP);
+                if (Craft::$app->request->isCpRequest) {
+                    Craft::$app->view->setTemplateMode(View::TEMPLATE_MODE_CP);
+                }
             }
         });
 
@@ -191,7 +193,9 @@ class ContactFormExtensions extends Plugin
                 Craft::$app->mailer->send($message);
 
                 // Set the template mode back to Control Panel
-                Craft::$app->view->setTemplateMode(View::TEMPLATE_MODE_CP);
+                if (Craft::$app->request->isCpRequest) {
+                    Craft::$app->view->setTemplateMode(View::TEMPLATE_MODE_CP);
+                }
             }
         });
 


### PR DESCRIPTION
This PR checks that this is a CP request before changing the template mode, otherwise the plugin may break the subsequent template that should be rendered.