### PR TITLE
Fix Google RecaptchaV3 token request

### DIFF
--- a/src/models/RecaptchaV3.php
+++ b/src/models/RecaptchaV3.php
@@ -39,9 +39,27 @@ class RecaptchaV3
                 <script src="${api_uri}?render=${siteKey}"></script>
                 <script>
                   grecaptcha.ready(function() {
-                      grecaptcha.execute('${siteKey}', {action: '${action}'}).then(function(token) {
-                         document.getElementById('g-recaptcha-response').value = token;
-                      });
+                      var input=document.getElementById('g-recaptcha-response');
+                      var form=input.parentElement;
+                      while(form && form.tagName.toLowerCase()!='form') {
+                          form = form.parentElement;
+                      }
+
+                      if (form) {
+                          form.addEventListener('submit',function(e) {
+                              e.preventDefault();  
+                              e.stopImmediatePropagation();
+
+                              if (input.value == '') {
+                                  grecaptcha.execute('${siteKey}', {action: '${action}'}).then(function(token) {
+                                      input.value = token;                                      
+                                      form.submit();
+                                  });
+                              }
+
+                              return false;
+                          },false);
+                      }
                   });
                 </script>
                 <input type="hidden" id="g-recaptcha-response" name="g-recaptcha-response" value="">


### PR DESCRIPTION
This PR fixes an issue with the Google RecaptchaV3 token request. RecaptchaV3 tokens have to be submitted to the backend for verification immediately after requesting them in order to avoid a timeout-or-duplicate error during the verification request on the backend. If the user takes a few minutes to fill out the form, the timeout-or-duplicate error will subsequently lead to the request being marked as spam by the extension. If the user submits the request before the timeout occurs after 2-3 minutes, the code works as expected.

https://developers.google.com/recaptcha/docs/v3
_"Note: reCAPTCHA tokens expire after two minutes. If you're protecting an action with reCAPTCHA, make sure to call execute when the user takes the action rather than on page load."_

Reproduce issue:
1. Load form containing {{ craft.contactFormExtensions.recaptcha | raw }} in browser.
2. Wait 2-3 minutes before submitting the form

Changes:
1. The extension is automatically searching for the parent form of the input field that transfers the token.
2. An onsubmit event is attached to the form to stop the default submission process and to request the Google Recaptcha Token.
3. As soon as the Recaptcha Token has been received, the form is submitted.

Potential drawbacks of the changes:
1. The developer needs to be aware of other JS events attached to the form that might interfere with the submit event attached by the extension. If the submit event attached by the extension does not get triggered correctly, the token will never get added to the request data, leading to an empty response during the token verification on the backend.
2. There might be a slight noticeable delay between the user starting the submission of the form and it actually submitting (due to the wait for the Recaptcha token). This issue could be mitigated by adding additional visual feedback for the user as soon as the submission process starts (ie. a loading icon).