### PR TITLE
Execute contact-form mailer event handlers after other plugins'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Fixed an issue where submissions flagged as spam by other plugins (eg: contact-form-honeypot) would still be saved in the database (fixes [#80](https://github.com/hybridinteractive/craft-contact-form-extensions/issues/80), [#32](https://github.com/hybridinteractive/craft-contact-form-extensions/issues/32))
+
 ## [4.2.2] - 2022-11-14
 Fixed an issue where the settings tabs were not showing [#164](https://github.com/hybridinteractive/craft-contact-form-extensions/issues/164)
 

--- a/src/ContactFormExtensions.php
+++ b/src/ContactFormExtensions.php
@@ -173,7 +173,7 @@ class ContactFormExtensions extends Plugin
     private function _registerContactFormEventListeners(): void
     {
         // Wait until all plugins are initialized to bind CraftContactFormMailer events, to ensure their handlers will be executed after handlers from other plugins
-        Event::on(Plugins::class, Plugins::EVENT_AFTER_LOAD_PLUGINS, function() {
+        Event::on(Plugins::class, Plugins::EVENT_AFTER_LOAD_PLUGINS, function () {
             // Capture Before Send Event from Craft Contact Form plugin
             Event::on(CraftContactFormMailer::class, CraftContactFormMailer::EVENT_BEFORE_SEND, function (CraftContactFormSendEvent $e) {
                 if ($e->isSpam) {


### PR DESCRIPTION
This PR ensures all plugins got a chance to mark a submission as spam before running the CraftContactFormMailer handlers.

This fixes #32 & #80 and works well with #185.