### PR TITLE
Replace infected polyfill.io cdn

### DIFF
--- a/src/InvisibleReCaptcha.php
+++ b/src/InvisibleReCaptcha.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace hybridinteractive\contactformextensions;
+
+use AlbertCht\InvisibleReCaptcha\InvisibleReCaptcha as BaseInvisibleReCaptcha;
+
+class InvisibleReCaptcha extends BaseInvisibleReCaptcha
+{
+    const POLYFILL_URI = 'https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js';
+}

--- a/src/services/ContactFormExtensionsService.php
+++ b/src/services/ContactFormExtensionsService.php
@@ -93,7 +93,7 @@ class ContactFormExtensionsService extends Component
             'debug'     => ContactFormExtensions::$plugin->settings->recaptchaDebug,
         ];
 
-        return new \AlbertCht\InvisibleReCaptcha\InvisibleReCaptcha($siteKey, $secretKey, $options);
+        return new \hybridinteractive\contactformextensions\InvisibleReCaptcha($siteKey, $secretKey, $options);
     }
 
     /**


### PR DESCRIPTION
Hi!

An [issue](https://github.com/hybridinteractive/craft-contact-form-extensions/issues/191) has been opened in this repository regarding a dependency with an infected CDN. A [PR](https://github.com/albertcht/invisible-recaptcha/pull/173) to remove the infected polyfill CDN has been made, but looking at the repository activity, chances of it being merged soon seem low. This PR offers a temporary workaround until the PR in `albertcht/invisible-recaptcha` is merged.