### PR TITLE
Fix deprecration error for |ucfirst

### DIFF
--- a/src/templates/submissions/_show.twig
+++ b/src/templates/submissions/_show.twig
@@ -31,7 +31,7 @@
             <h3>{{ "From email"|t('contact-form-extensions') }}</h3>
             <p>{{ submission.fromEmail }}</p>
             {% for key, value in messageObject %}
-                <h3>{{ key|ucfirst|t('contact-form-extensions') }}</h3>
+                <h3>{{ key|capitalize|t('contact-form-extensions') }}</h3>
                 {% if value is iterable %}
                     {% for item in value %}
                         <p>{{ item|nl2br }}</p>


### PR DESCRIPTION
The `ucfirst` filter is deprecated in Craft 5. This updates the template reference.

> The |ucfirst filter has been deprecated. Use |capitalize instead.