### PR TITLE
Add autopruning queue job functionality / Fix ineffecient query used in or by element index 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "hybridinteractive/craft-contact-form-extensions",
   "description": "Adds extensions to the Craft CMS contact form plugin.",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "type": "craft-plugin",
   "keywords": [
     "cms",

--- a/src/ContactFormExtensions.php
+++ b/src/ContactFormExtensions.php
@@ -81,6 +81,44 @@ class ContactFormExtensions extends Plugin
         if (Craft::$app->getRequest()->getIsCpRequest()) {
             $this->_registerCpRoutes();
         }
+
+        // Schedule the initial prune job (runs once, then self-reschedules)
+        $this->_scheduleInitialPruneJob();
+    }
+
+    /**
+     * Schedule the initial prune job (runs once, then self-reschedules).
+     */
+    private function _scheduleInitialPruneJob(): void
+    {
+        $request = Craft::$app->getRequest();
+        $settings = $this->getSettings();
+
+        // Only run in CP or console, and only if pruning is enabled
+        if (!($request->getIsCpRequest() || $request->getIsConsoleRequest())) {
+            return;
+        }
+
+        if (!$settings->enableDatabase || !$settings->pruneAfterDays || $settings->pruneAfterDays <= 0) {
+            return;
+        }
+
+        $cache = Craft::$app->cache;
+        $lockKey = 'contactFormExtensions_pruneJobScheduled';
+
+        // Check if we've already scheduled the recurring job (cache for 7 days)
+        if ($cache->get($lockKey)) {
+            return;
+        }
+
+        // Set a long-lived flag so we don't reschedule on every request
+        $cache->set($lockKey, true, 604800); // 7 days
+
+        Craft::info('[CFE] Scheduling initial self-rescheduling prune job', __METHOD__);
+
+        Craft::$app->queue->push(new \hybridinteractive\contactformextensions\jobs\PruneSubmissionsJob([
+            'reschedule' => true,
+        ]));
     }
 
     /**
@@ -274,7 +312,7 @@ class ContactFormExtensions extends Plugin
                 $message->setTo($e->submission->fromEmail);
 
                 if (isset(App::mailSettings()->fromEmail)) {
-                    $message->setFrom([Craft::parseEnv(App::mailSettings()->fromEmail) => Craft::parseEnv(App::mailSettings()->fromName)]);
+                    $message->setFrom([App::parseEnv(App::mailSettings()->fromEmail) => App::parseEnv(App::mailSettings()->fromName)]);
                 } else {
                     $message->setFrom($e->message->getTo());
                 }

--- a/src/base/Routes.php
+++ b/src/base/Routes.php
@@ -2,6 +2,7 @@
 
 namespace hybridinteractive\contactformextensions\base;
 
+use Craft;
 use craft\events\RegisterUrlRulesEvent;
 use craft\web\UrlManager;
 use yii\base\Event;
@@ -18,9 +19,13 @@ trait Routes
      */
     public function _registerCpRoutes(): void
     {
-        Event::on(UrlManager::class, UrlManager::EVENT_REGISTER_CP_URL_RULES, function (RegisterUrlRulesEvent $event) {
-            $event->rules['contact-form-extensions/submissions/<submissionId:\d+>'] = 'contact-form-extensions/submissions/show-submission';
-            $event->rules['contact-form-extensions/submissions/<submissionId:\d+>/<siteHandle:{handle}>'] = 'contact-form-extensions/submissions/show-submission';
+        Event::on(
+            UrlManager::class, 
+            UrlManager::EVENT_REGISTER_CP_URL_RULES, 
+            function (RegisterUrlRulesEvent $event) {
+                $event->rules['contact-form-extensions/submissions/<submissionId:\d+>'] = 'contact-form-extensions/submissions/show-submission';
+                
+                $event->rules['contact-form-extensions/submissions/<submissionId:\d+>/<siteHandle:{handle}>'] = 'contact-form-extensions/submissions/show-submission';
         });
     }
 }

--- a/src/config.php
+++ b/src/config.php
@@ -39,4 +39,6 @@ return [
     'recaptchaTimeout'        => 5,
     'recaptchaThreshold'      => .5,
     'recaptchaDebug'          => false,
+
+    'pruneAfterDays'          => 30,
 ];

--- a/src/console/controllers/CleanupController.php
+++ b/src/console/controllers/CleanupController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace hybridinteractive\contactformextensions\console\controllers;
+
+use Craft;
+use craft\console\Controller;
+use hybridinteractive\contactformextensions\ContactFormExtensions;
+use hybridinteractive\contactformextensions\elements\Submission;
+use yii\console\ExitCode;
+
+class CleanupController extends Controller
+{
+    public $defaultAction = 'soft-deleted';
+
+    /**
+     * Hard-delete all soft-deleted submissions from the database.
+     *
+     * @return int
+     */
+    public function actionSoftDeleted(): int
+    {
+        $this->stdout("=== Contact Form Extensions - Cleanup Soft-Deleted ===\n");
+        
+        // Find all trashed submissions
+        $query = Submission::find()
+            ->trashed()
+            ->status(null)
+            ->limit(null);
+
+        $count = $query->count();
+        
+        if ($count === 0) {
+            $this->stdout("\n✓ No soft-deleted submissions found.\n");
+            return ExitCode::OK;
+        }
+
+        $this->stdout("\nFound {$count} soft-deleted submissions.\n");
+        $this->stdout("Hard-deleting them permanently...\n");
+
+        $elementsService = Craft::$app->getElements();
+        $i = 0;
+        $deleteCount = 0;
+        $batchSize = 100;
+        
+        // Process in batches
+        for ($offset = 0; $offset < $count; $offset += $batchSize) {
+            $submissions = Submission::find()
+                ->trashed()
+                ->status(null)
+                ->limit($batchSize)
+                ->offset($offset)
+                ->all();
+            
+            foreach ($submissions as $submission) {
+                // Hard delete = permanently remove from database
+                $elementsService->deleteElement($submission, true);
+                $deleteCount = ++$i;
+                
+                if ($i % 1000 === 0) {
+                    $this->stdout("  Deleted {$i} / {$count}...\n");
+                }
+            }
+        }
+
+        $this->stdout("\n✓ Successfully hard-deleted {$deleteCount} soft-deleted submissions.\n");
+        
+        return ExitCode::OK;
+    }
+
+    /**
+     * Show database statistics for form submissions.
+     *
+     * @return int
+     */
+    public function actionStats(): int
+    {
+        $this->stdout("=== Contact Form Extensions - Database Stats ===\n\n");
+
+        $activeCount = Submission::find()->count();
+        $trashedCount = Submission::find()->trashed()->count();
+        $totalCount = Submission::find()->status(null)->trashed(null)->count();
+
+        $this->stdout("Active submissions:  {$activeCount}\n");
+        $this->stdout("Trashed submissions: {$trashedCount}\n");
+        $this->stdout("Total in DB:         {$totalCount}\n");
+
+        return ExitCode::OK;
+    }
+}

--- a/src/console/controllers/PruneController.php
+++ b/src/console/controllers/PruneController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace hybridinteractive\contactformextensions\console\controllers;
+
+use Craft;
+use craft\console\Controller;
+use hybridinteractive\contactformextensions\ContactFormExtensions;
+use hybridinteractive\contactformextensions\elements\Submission;
+use hybridinteractive\contactformextensions\jobs\PruneSubmissionsJob;
+use yii\console\ExitCode;
+
+class PruneController extends Controller
+{
+    public $defaultAction = 'run';
+
+    /**
+     * Manually trigger a prune job (does not reschedule).
+     *
+     * @return int
+     */
+    public function actionRun(): int
+    {
+        $this->stdout("=== Contact Form Extensions - Prune Command ===\n");
+        
+        $settings = ContactFormExtensions::$plugin->getSettings();
+        $days = $settings->pruneAfterDays ?? 0;
+        
+        $this->stdout("Settings retrieved:\n");
+        $this->stdout("  - pruneAfterDays: {$days}\n");
+        $this->stdout("  - Type: " . gettype($days) . "\n");
+
+        if (!is_numeric($days) || $days <= 0) {
+            $this->stdout("\n❌ Pruning is disabled or not configured (pruneAfterDays = {$days}).\n");
+            $this->stdout("   To enable, go to Settings → Plugins → Contact Form Extensions\n");
+            $this->stdout("   and set 'Auto-prune submissions after (days)' to a positive number.\n");
+            return ExitCode::OK;
+        }
+
+        // Calculate cutoff date
+        $now = new \DateTime();
+        $cutoffDate = (new \DateTime())->modify("-{$days} days");
+        
+        $this->stdout("\nDate calculations:\n");
+        $this->stdout("  - Current date: " . $now->format('Y-m-d H:i:s') . "\n");
+        $this->stdout("  - Cutoff date: " . $cutoffDate->format('Y-m-d H:i:s') . "\n");
+        $this->stdout("  - Will delete submissions created before: " . $cutoffDate->format('Y-m-d H:i:s') . "\n");
+
+        // Count submissions to be pruned
+        $this->stdout("\nQuerying submissions...\n");
+        
+        $query = Submission::find()
+            ->dateCreated('< ' . $cutoffDate->format('Y-m-d H:i:s'))
+            ->status(null);
+        
+        $count = $query->count();
+        
+        $this->stdout("  - Found {$count} submissions older than {$days} days\n");
+
+        if ($count === 0) {
+            $this->stdout("\n✓ No submissions to prune.\n");
+            return ExitCode::OK;
+        }
+
+        // Queue the prune job
+        $this->stdout("\nQueueing prune job...\n");
+        
+        Craft::$app->queue->push(new PruneSubmissionsJob([
+            'reschedule' => false, // Don't reschedule when run manually
+        ]));
+
+        $this->stdout("✓ Queued prune job for {$count} submissions older than {$days} days.\n");
+        $this->stdout("  The job will process in the background.\n");
+        
+        return ExitCode::OK;
+    }
+}

--- a/src/elements/Submission.php
+++ b/src/elements/Submission.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Craft Contact Form Extensions plugin for Craft CMS 4.x.
- *
- * Adds extensions to the Craft CMS contact form plugin.
- */
 
 namespace hybridinteractive\contactformextensions\elements;
 
 use Craft;
 use craft\base\Element;
+use craft\db\Query;
 use craft\elements\actions\Delete;
 use craft\elements\db\ElementQueryInterface;
 use craft\helpers\StringHelper;
@@ -17,30 +13,33 @@ use hybridinteractive\contactformextensions\elements\db\SubmissionQuery;
 
 class Submission extends Element
 {
-    // Public Properties
-    // =========================================================================
-
-    public ?string $form;
-    public ?string $fromName;
-    public ?string $fromEmail;
-    public ?string $subject;
+    public ?string $form = null;
+    public ?string $fromName = null;
+    public ?string $fromEmail = null;
+    public ?string $subject = null;
     public $message;
 
-    // Static Methods
-    // =========================================================================
+    // ─────────────────────────────────────────
+    // Core element behavior
+    // ─────────────────────────────────────────
 
-    /**
-     * @inheritDoc
-     */
     public static function hasContent(): bool
     {
-        return true;
+        // All data lives in contactform_submissions, not content table
+        return false;
     }
 
-    /**
-     * @inheritDoc
-     */
+    public static function hasTitles(): bool
+    {
+        return false;
+    }
+
     public static function isLocalized(): bool
+    {
+        return false;
+    }
+
+    public static function hasStatuses(): bool
     {
         return false;
     }
@@ -67,29 +66,37 @@ class Submission extends Element
 
     public function getCpEditUrl(): ?string
     {
-        return UrlHelper::cpUrl('contact-form-extensions/submissions/'.$this->id);
+        return UrlHelper::cpUrl('contact-form-extensions/submissions/' . $this->id);
     }
 
-    /**
-     * @inheritDoc
-     */
-    protected static function defineSources(string $context = null): array
-    {
-        $forms = array_unique(array_map(function (self $submission) {
-            return $submission->form;
-        }, self::find()->all()));
+    // ─────────────────────────────────────────
+    // Sources (left-hand filter in CP index)
+    // ─────────────────────────────────────────
 
+    protected static function defineSources(?string $context = null): array
+    {
         $sources = [
             [
                 'key'      => '*',
                 'label'    => Craft::t('contact-form-extensions', 'All submissions'),
                 'criteria' => [],
+                'default'  => true,
             ],
         ];
 
+        // ⚠ Previously this did self::find()->all() → catastrophic on 167k rows
+        // Use a lightweight DB query to get distinct form handles instead
+        $forms = (new Query())
+            ->select(['form'])
+            ->from('{{%contactform_submissions}}')
+            ->where(['not', ['form' => null]])
+            ->distinct()
+            ->orderBy(['form' => SORT_ASC])
+            ->column();
+
         foreach ($forms as $formHandle) {
             $sources[] = [
-                'key'      => $formHandle,
+                'key'      => 'form:' . $formHandle,
                 'label'    => ucfirst($formHandle),
                 'criteria' => ['form' => $formHandle],
             ];
@@ -98,30 +105,35 @@ class Submission extends Element
         return $sources;
     }
 
-    /**
-     * @inheritDoc
-     */
-    protected static function defineActions(string $source = null): array
+    // ─────────────────────────────────────────
+    // Actions
+    // ─────────────────────────────────────────
+
+    protected static function defineActions(?string $source = null): array
     {
         $elementsService = Craft::$app->getElements();
-
         $actions = parent::defineActions($source);
 
+        // $actions[] = $elementsService->createAction([
+        //     'type'                => Delete::class,
+        //     'confirmationMessage' => Craft::t('contact-form-extensions', 'Are you sure you want to delete the selected submissions?'),
+        //     'successMessage'      => Craft::t('contact-form-extensions', 'Submissions deleted.'),
+        // ]);
+
         $actions[] = $elementsService->createAction([
-            'type'                => Delete::class,
-            'confirmationMessage' => Craft::t('contact-form-extensions', 'Are you sure you want to delete the selected submissions?'),
-            'successMessage'      => Craft::t('contact-form-extensions', 'Submissions deleted.'),
+            'type' => \hybridinteractive\contactformextensions\elements\actions\QueueDeleteSubmissions::class,
         ]);
 
         return $actions;
     }
 
-    /**
-     * @inheritDoc
-     */
+    // ─────────────────────────────────────────
+    // Table columns
+    // ─────────────────────────────────────────
+
     protected static function defineTableAttributes(): array
     {
-        $attributes = [
+        return [
             'id'          => Craft::t('contact-form-extensions', 'ID'),
             'form'        => Craft::t('contact-form-extensions', 'Form'),
             'subject'     => Craft::t('contact-form-extensions', 'Subject'),
@@ -130,13 +142,8 @@ class Submission extends Element
             'message'     => Craft::t('contact-form-extensions', 'Message'),
             'dateCreated' => Craft::t('contact-form-extensions', 'Date Created'),
         ];
-
-        return $attributes;
     }
 
-    /**
-     * @inheritDoc
-     */
     protected static function defineDefaultTableAttributes(string $source): array
     {
         return [
@@ -150,20 +157,30 @@ class Submission extends Element
         ];
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getTableAttributeHtml(string $attribute): string
     {
-        if ($attribute == 'message') {
+        if ($attribute === 'message') {
             $message = (array) json_decode($this->message);
             $html = '<ul>';
+
             foreach ($message as $key => $value) {
-                if (is_string($value) && $key != 'formName' && $key != 'toEmail' && $key != 'confirmationSubject' && $key != 'confirmationTemplate' && $key != 'notificationTemplate' && $key != 'disableRecaptcha' && $key != 'disableConfirmation') {
+                if (
+                    is_string($value) &&
+                    !in_array($key, [
+                        'formName',
+                        'toEmail',
+                        'confirmationSubject',
+                        'confirmationTemplate',
+                        'notificationTemplate',
+                        'disableRecaptcha',
+                        'disableConfirmation',
+                    ], true)
+                ) {
                     $shortened = trim(substr($value, 0, 30));
                     $html .= "<li><em>{$key}</em>: {$shortened}...</li>";
                 }
             }
+
             $html .= '</ul>';
 
             return StringHelper::convertToUtf8($html);
@@ -172,25 +189,25 @@ class Submission extends Element
         return parent::getTableAttributeHtml($attribute);
     }
 
-    /**
-     * @inheritDoc
-     */
     protected static function defineSortOptions(): array
     {
-        $sortOptions = parent::defineSortOptions();
-
-        return $sortOptions;
+        return [
+            'dateCreated' => Craft::t('app', 'Date Created'),
+            'fromEmail'   => Craft::t('contact-form-extensions', 'From Email'),
+            'form'        => Craft::t('contact-form-extensions', 'Form'),
+        ];
     }
 
-    /**
-     * @param bool $isNew
-     *
-     * @throws \yii\db\Exception
-     */
+    // ─────────────────────────────────────────
+    // Persistence
+    // ─────────────────────────────────────────
+
     public function afterSave(bool $isNew): void
     {
+        $db = Craft::$app->db;
+
         if ($isNew) {
-            Craft::$app->db->createCommand()
+            $db->createCommand()
                 ->insert('{{%contactform_submissions}}', [
                     'id'        => $this->id,
                     'form'      => $this->form,
@@ -201,7 +218,7 @@ class Submission extends Element
                 ])
                 ->execute();
         } else {
-            Craft::$app->db->createCommand()
+            $db->createCommand()
                 ->update('{{%contactform_submissions}}', [
                     'form'      => $this->form,
                     'subject'   => $this->subject,

--- a/src/elements/actions/QueueDeleteSubmissions.php
+++ b/src/elements/actions/QueueDeleteSubmissions.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace hybridinteractive\contactformextensions\elements\actions;
+
+use Craft;
+use craft\base\ElementAction;
+use craft\elements\db\ElementQueryInterface;
+use hybridinteractive\contactformextensions\jobs\DeleteSubmissionsJob;
+
+class QueueDeleteSubmissions extends ElementAction
+{
+    public static function displayName(): string
+    {
+        return Craft::t('contact-form-extensions', 'Delete (queued)');
+    }
+
+    public function getConfirmationMessage(): ?string
+    {
+        return Craft::t('contact-form-extensions', 'Are you sure you want to delete the selected submissions? This will queue them for deletion in the background.');
+    }
+
+    public function performAction(ElementQueryInterface $query): bool
+    {
+        $ids = $query->ids();
+
+        Craft::$app->queue->push(new DeleteSubmissionsJob([
+            'ids' => $ids,
+        ]));
+
+        $this->setMessage(Craft::t('contact-form-extensions', 'Deletion queued.'));
+
+        return true;
+    }
+}

--- a/src/elements/db/SubmissionQuery.php
+++ b/src/elements/db/SubmissionQuery.php
@@ -2,6 +2,7 @@
 
 namespace hybridinteractive\contactformextensions\elements\db;
 
+use Craft;
 use craft\elements\db\ElementQuery;
 use craft\helpers\Db;
 
@@ -50,11 +51,10 @@ class SubmissionQuery extends ElementQuery
 
     protected function beforePrepare(): bool
     {
-        // join in the products table
         $this->joinElementTable('contactform_submissions');
 
-        // select the columns
         $this->query->select([
+            'elements.id',
             'contactform_submissions.form',
             'contactform_submissions.subject',
             'contactform_submissions.fromName',

--- a/src/jobs/DeleteSubmissionsJob.php
+++ b/src/jobs/DeleteSubmissionsJob.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace hybridinteractive\contactformextensions\jobs;
+
+use Craft;
+use craft\queue\BaseJob;
+use hybridinteractive\contactformextensions\elements\Submission;
+
+class DeleteSubmissionsJob extends BaseJob
+{
+    /** @var int[] */
+    public array $ids = [];
+
+    public function execute($queue): void
+    {
+        $elementsService = Craft::$app->getElements();
+        $total = count($this->ids);
+
+        if ($total === 0) {
+            return;
+        }
+
+        /** @var \craft\elements\db\ElementQuery $query */
+        $query = Submission::find()
+            ->id($this->ids)
+            ->status(null)     // IMPORTANT: allow deletion of disabled/draft/etc
+            ->siteId('*')      // IMPORTANT: ensure it retrieves the element in any site
+            ->limit(null);     // IMPORTANT: avoid Craft falling back to a default limit
+
+        $i = 0;
+
+        foreach ($query->each(100) as $submission) {
+            // Hard delete = true to permanently remove from database
+            $elementsService->deleteElement($submission, true);
+            $this->setProgress($queue, ++$i / $total);
+        }
+    }
+
+    protected function defaultDescription(): string
+    {
+        return Craft::t('contact-form-extensions', 'Deleting submissions…');
+    }
+}

--- a/src/jobs/PruneSubmissionsJob.php
+++ b/src/jobs/PruneSubmissionsJob.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace hybridinteractive\contactformextensions\jobs;
+
+use Craft;
+use craft\queue\BaseJob;
+use hybridinteractive\contactformextensions\ContactFormExtensions;
+use hybridinteractive\contactformextensions\elements\Submission;
+
+class PruneSubmissionsJob extends BaseJob
+{
+    /**
+     * Whether to reschedule this job after completion
+     */
+    public bool $reschedule = true;
+
+    public function execute($queue): void
+    {
+        // Always get days from settings to ensure consistency
+        $settings = ContactFormExtensions::$plugin->getSettings();
+        $days = $settings->pruneAfterDays;
+
+        if ($days <= 0) {
+            Craft::info('[CFE] Pruning skipped: pruneAfterDays is not configured', __METHOD__);
+            return;
+        }
+
+        $cutoff = (new \DateTime())->modify("-{$days} days");
+
+        /** @var \craft\elements\db\ElementQuery $query */
+        $query = Submission::find()
+            ->dateCreated('< ' . $cutoff->format('Y-m-d H:i:s'))
+            ->status(null)
+            ->siteId('*')
+            ->limit(null);
+
+        $total = $query->count();
+        
+        Craft::info("[CFE] Pruning {$total} submissions older than {$days} days", __METHOD__);
+
+        if ($total > 0) {
+            $i = 0;
+            $elementsService = Craft::$app->getElements();
+
+            foreach ($query->each(100) as $submission) {
+                // Hard delete = true to permanently remove from database
+                $elementsService->deleteElement($submission, true);
+                $this->setProgress($queue, ++$i / $total);
+            }
+        }
+
+        // Reschedule the job if enabled
+        if ($this->reschedule) {
+            // Recheck settings in case they changed
+            $settings = ContactFormExtensions::$plugin->getSettings();
+            
+            if ($settings->enableDatabase && $settings->pruneAfterDays > 0) {
+                // Schedule next run in 6 hours (21600 seconds)
+                $delay = 21600;
+                
+                Craft::$app->queue->delay($delay)->push(new self([
+                    'reschedule' => true,
+                ]));
+                
+                Craft::info("[CFE] Rescheduled prune job to run in {$delay} seconds", __METHOD__);
+            }
+        }
+    }
+
+    protected function defaultDescription(): ?string
+    {
+        $settings = ContactFormExtensions::$plugin->getSettings();
+        $days = $settings->pruneAfterDays ?? 30;
+        
+        return Craft::t('contact-form-extensions', 'Pruning form submissions older than {days} days', [
+            'days' => $days,
+        ]);
+    }
+}

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -115,6 +115,12 @@ class Settings extends Model
      */
     public $recaptchaThreshold = 0.5;
 
+    /**
+     * @var int
+     */
+    public int $pruneAfterDays = 0;
+
+
     // Public Methods
     // =========================================================================
 
@@ -142,6 +148,7 @@ class Settings extends Model
 
             ['recaptchaTimeout', 'integer'],
             ['recaptchaThreshold', 'double', 'max' => 1, 'min' => 0],
+            ['pruneAfterDays', 'integer', 'min' => 0],
 
             [['confirmationTemplate', 'confirmationSubject'], 'required', 'when' => static function ($model) {
                 return $model->enableConfirmationEmail == true;

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -21,6 +21,19 @@
         on: settings.enableDatabase == true
     }) }}
 
+    {{ forms.textField({
+        label: 'Auto-prune submissions after (days)',
+        instructions: 'Automatically delete form submissions older than this many days. Set to 0 to disable automatic pruning. The prune job runs every 6 hours.',
+        id: 'pruneAfterDays',
+        name: 'pruneAfterDays',
+        type: 'number',
+        min: 0,
+        disabled: 'pruneAfterDays' in overrides,
+        warning: 'pruneAfterDays' in overrides ? configWarning('pruneAfterDays'),
+        value: settings.pruneAfterDays,
+        errors: settings.getErrors('pruneAfterDays'),
+    }) }}
+
     {{ forms.lightswitchField({
         label: 'Send confirmation email',
         instructions: 'Sends a confirmation email to the person who filled in the contact form, a `fromEmail` field is required.',

--- a/src/variables/ContactFormExtensionsVariable.php
+++ b/src/variables/ContactFormExtensionsVariable.php
@@ -19,7 +19,7 @@ class ContactFormExtensionsVariable
         return ContactFormExtensions::$plugin->name;
     }
 
-    public function recaptcha(string $localeOrAction = null)
+    public function recaptcha(?string $localeOrAction = null)
     {
         if (ContactFormExtensions::$plugin->settings->recaptcha) {
             return ContactFormExtensions::$plugin->contactFormExtensionsService->getRecaptcha()->render($localeOrAction);
@@ -28,12 +28,23 @@ class ContactFormExtensionsVariable
         return '';
     }
 
-    public function submissions($criteria = null): ElementQueryInterface
+    public function submissions(array $criteria = []): ElementQueryInterface
     {
         $query = Submission::find();
 
-        if ($criteria) {
+        // Apply any passed criteria (form, subject, fromEmail, etc.)
+        if (!empty($criteria)) {
             Craft::configure($query, $criteria);
+        }
+
+        // Sensible default ordering: newest first
+        if ($query->orderBy === null) {
+            $query->orderBy(['elements.dateCreated' => SORT_DESC]);
+        }
+
+        // Safety net: if no limit specified, default to something sane
+        if ($query->limit === null) {
+            $query->limit(50);
         }
 
         return $query;


### PR DESCRIPTION
We had a client with 167k submissions (mostly legitimate too) over many years and on looking the other day the CFE admin CP section was just hanging so this fixes, improves and adds additional functionality to:

- Fix CP OOM issue (Submission element define sources query inefficiency)
- Add optional auto pruning functionality with configurable no of days, and respective queue jobs for deleting Submission Elements and related data thoroughly
- Console commands to help with cleanup ops
- Bump version number to match latest tag?